### PR TITLE
fix: proper cmdbar_extra_bg color

### DIFF
--- a/theme/frappe.ron
+++ b/theme/frappe.ron
@@ -4,7 +4,7 @@
     selection_bg: Rgb(98, 104, 128),
     selection_fg: Rgb(198, 208, 245),
     cmdbar_bg: Rgb(41, 44, 60),
-    cmdbar_extra_lines_bg: Rgb(153, 209, 219),
+    cmdbar_extra_lines_bg: Rgb(41, 44, 60),
     disabled_fg: Rgb(131, 139, 167),
     diff_line_add: Rgb(166, 209, 137),
     diff_line_delete: Rgb(231, 130, 132),

--- a/theme/latte.ron
+++ b/theme/latte.ron
@@ -4,7 +4,7 @@
     selection_bg: Rgb(172, 176, 190),
     selection_fg: Rgb(76, 79, 105),
     cmdbar_bg: Rgb(230, 233, 239),
-    cmdbar_extra_lines_bg: Rgb(4, 165, 229),
+    cmdbar_extra_lines_bg: Rgb(230, 233, 239),
     disabled_fg: Rgb(140, 143, 161),
     diff_line_add: Rgb(64, 160, 43),
     diff_line_delete: Rgb(210, 15, 57),

--- a/theme/macchiato.ron
+++ b/theme/macchiato.ron
@@ -4,7 +4,7 @@
     selection_bg: Rgb(91, 96, 120),
     selection_fg: Rgb(202, 211, 245),
     cmdbar_bg: Rgb(30, 32, 48),
-    cmdbar_extra_lines_bg: Rgb(145, 215, 227),
+    cmdbar_extra_lines_bg: Rgb(30, 32, 48),
     disabled_fg: Rgb(128, 135, 162),
     diff_line_add: Rgb(166, 218, 149),
     diff_line_delete: Rgb(237, 135, 150),

--- a/theme/mocha.ron
+++ b/theme/mocha.ron
@@ -4,7 +4,7 @@
     selection_bg: Rgb(88, 91, 112),
     selection_fg: Rgb(205, 214, 244),
     cmdbar_bg: Rgb(24, 24, 37),
-    cmdbar_extra_lines_bg: Rgb(137, 220, 235),
+    cmdbar_extra_lines_bg: Rgb(24, 24, 37),
     disabled_fg: Rgb(127, 132, 156),
     diff_line_add: Rgb(166, 227, 161),
     diff_line_delete: Rgb(243, 139, 168),


### PR DESCRIPTION
Well, This PR follows up on the issue I mentioned a few days ago. #1 
And as you can see, the change made is that the background is now the same color. Wdyt @BlueFalconHD?

Before :
![image](https://user-images.githubusercontent.com/49778014/203353276-0617b6a4-cacf-4fb7-9063-fde75e6a8f0b.png) 

After:
![image](https://user-images.githubusercontent.com/49778014/203353469-a28ef175-2c93-4134-bd85-b756c0f8bd12.png) 
