### PR TITLE
Using same color from added lines on added files (#7)

### DIFF
--- a/theme/frappe.ron
+++ b/theme/frappe.ron
@@ -8,7 +8,7 @@
     disabled_fg: Some(Rgb(131, 139, 167)),
     diff_line_add: Some(Rgb(166, 209, 137)),
     diff_line_delete: Some(Rgb(231, 130, 132)),
-    diff_file_added: Some(Rgb(229, 200, 144)),
+    diff_file_added: Some(Rgb(166, 209, 137)),
     diff_file_removed: Some(Rgb(234, 153, 156)),
     diff_file_moved: Some(Rgb(202, 158, 230)),
     diff_file_modified: Some(Rgb(239, 159, 118)),

--- a/theme/latte.ron
+++ b/theme/latte.ron
@@ -8,7 +8,7 @@
     disabled_fg: Some(Rgb(140, 143, 161)),
     diff_line_add: Some(Rgb(64, 160, 43)),
     diff_line_delete: Some(Rgb(210, 15, 57)),
-    diff_file_added: Some(Rgb(223, 142, 29)),
+    diff_file_added: Some(Rgb(64, 160, 43)),
     diff_file_removed: Some(Rgb(230, 69, 83)),
     diff_file_moved: Some(Rgb(136, 57, 239)),
     diff_file_modified: Some(Rgb(254, 100, 11)),

--- a/theme/macchiato.ron
+++ b/theme/macchiato.ron
@@ -8,7 +8,7 @@
     disabled_fg: Some(Rgb(128, 135, 162)),
     diff_line_add: Some(Rgb(166, 218, 149)),
     diff_line_delete: Some(Rgb(237, 135, 150)),
-    diff_file_added: Some(Rgb(238, 212, 159)),
+    diff_file_added: Some(Rgb(166, 218, 149)),
     diff_file_removed: Some(Rgb(238, 153, 160)),
     diff_file_moved: Some(Rgb(198, 160, 246)),
     diff_file_modified: Some(Rgb(245, 169, 127)),

--- a/theme/mocha.ron
+++ b/theme/mocha.ron
@@ -8,7 +8,7 @@
     disabled_fg: Some(Rgb(127, 132, 156)),
     diff_line_add: Some(Rgb(166, 227, 161)),
     diff_line_delete: Some(Rgb(243, 139, 168)),
-    diff_file_added: Some(Rgb(249, 226, 175)),
+    diff_file_added: Some(Rgb(166, 227, 161)),
     diff_file_removed: Some(Rgb(235, 160, 172)),
     diff_file_moved: Some(Rgb(203, 166, 247)),
     diff_file_modified: Some(Rgb(250, 179, 135)),


### PR DESCRIPTION
As I mentioned in issue #7, that PR uses the same color scheme as the "added lines" color. This will improve UX and make it easier to differentiate between changes and added lines in git files.